### PR TITLE
Option to disable prepared statements for all connections in the pool (close #3)

### DIFF
--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -45,14 +45,15 @@ type PGPool = RP.Pool PGConn
 
 data ConnParams
   = ConnParams
-    { cpStripes  :: !Int
-    , cpConns    :: !Int
-    , cpIdleTime :: !Int
+    { cpStripes      :: !Int
+    , cpConns        :: !Int
+    , cpIdleTime     :: !Int
+    , cpAllowPrepare :: !Bool
     }
   deriving (Show, Eq)
 
 defaultConnParams :: ConnParams
-defaultConnParams = ConnParams 1 20 60
+defaultConnParams = ConnParams 1 20 60 True
 
 initPGPool :: ConnInfo
            -> ConnParams
@@ -66,7 +67,7 @@ initPGPool ci cp =
       pqConn  <- initPQConn ci
       ctr     <- newIORef 0
       table   <- HI.new
-      return $ PGConn pqConn ctr table
+      return $ PGConn pqConn (cpAllowPrepare cp) ctr table
     destroyer = PQ.finish . pgPQConn
     diffTime  = fromIntegral $ cpIdleTime cp
 


### PR DESCRIPTION
- Boolean Field in Postgres Connection data type to track whether prepared statements are allowed (`pgAllowPrepare`)
- Only allow prepared statements if pgAllowPrepare is set and if the statement is preparable 
- Boolean Field in the Connection Parameters configuration for the Postgres Connection pool  (`cpAllowPrepare`: Used to set pgAllowPrepare in PGConn)