### PR TITLE
Binary encoding for multi-dimensional arrays of Postgres built-in types (close #8)

### DIFF
--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -44,6 +44,7 @@ library
                      , hashtables
                      , time >= 1.6
                      , vector
+                     , unordered-containers
                      , scientific >= 0.3
 
                      , postgresql-libpq

--- a/src/Database/PG/Query/Class.hs
+++ b/src/Database/PG/Query/Class.hs
@@ -1,6 +1,16 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TemplateHaskellQuotes      #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 module Database.PG.Query.Class
        ( WithCount(..)
        , WithReturning(..)
@@ -16,14 +26,19 @@ module Database.PG.Query.Class
        , AltJ(..)
        , JSON (..)
        , JSONB (..)
+       , BinaryEncBuiltInTy(..)
+       , ToPrepArgBin
        ) where
 
 import           Control.Monad.Except
 import           Control.Monad.Identity
+import           Data.Foldable
 import           Data.Int
+import           Data.Proxy
 import           Data.Scientific                  (Scientific)
 import           Data.Time
 import           Data.Word
+import           Foreign.C.Types
 import           GHC.Exts
 
 import qualified Data.Aeson                       as J
@@ -426,70 +441,231 @@ instance ToPrepArg PrepArg where
 toPrepValHelper :: PQ.Oid -> (a -> PE.Encoding) -> a -> PrepArg
 toPrepValHelper o e a = (o, Just (PE.encodingBytes $ e a, PQ.Binary))
 
-instance (J.ToJSON a) => ToPrepArg (AltJ a) where
-  toPrepVal (AltJ a)  = toPrepValHelper PTI.json PE.bytea_lazy $ J.encode a
+data InstanceTy
+  = Elem
+  | ArrOf InstanceTy
+  | VectOf InstanceTy
+  | Other
+  deriving (Show, Eq)
 
-instance ToPrepArg Word64 where
-  toPrepVal = toPrepValHelper PTI.int8 PE.int8_word64
 
-instance ToPrepArg Int64 where
-  toPrepVal = toPrepValHelper PTI.int8 PE.int8_int64
+type family (F a) :: InstanceTy where
+  F (Maybe a)               = F a
+  F [a]                     = 'ArrOf (F a)
+  F (V.Vector a)            = 'VectOf (F a)
+  F (AltJ a)                = 'Elem
+  F Word64                  = 'Elem
+  F Int64                   = 'Elem
+  F Int32                   = 'Elem
+  F Int16                   = 'Elem
+  F Float                   = 'Elem
+  F Double                  = 'Elem
+  F Scientific              = 'Elem
+  F Char                    = 'Elem
+  F T.Text                  = 'Elem
+  F TL.Text                 = 'Elem
+  F B.ByteString            = 'Elem
+  F BL.ByteString           = 'Elem
+  F JSON                    = 'Elem
+  F JSONB                   = 'Elem
+  F LocalTime               = 'Elem
+  F UTCTime                 = 'Elem
+  F Bool                    = 'Elem
+  F _                       = 'Other
 
-instance ToPrepArg Int32 where
-  toPrepVal = toPrepValHelper PTI.int4 PE.int4_int32
+type PrepArgBinEnc = (PQ.Oid, Maybe PE.Encoding)
 
-instance ToPrepArg Int16 where
-  toPrepVal = toPrepValHelper PTI.int2 PE.int2_int16
+type ToPrepArgBin a = ToPrepArgBin' (F a) a
 
-instance ToPrepArg Float where
-  toPrepVal = toPrepValHelper PTI.float4 PE.float4
+class ToPrepArgBin' (instncTy :: InstanceTy) a where
+  toPrepVal' :: Proxy instncTy -> a -> PrepArgBinEnc
 
-instance ToPrepArg Double where
-  toPrepVal = toPrepValHelper PTI.float8 PE.float8
+instance {-# OVERLAPPABLE #-} (F a ~ instncTy, ToPrepArgBin' instncTy a) => ToPrepArg a where
+  toPrepVal x =
+    ( oid
+    , (,PQ.Binary) . PE.encodingBytes <$> binEnc
+    )
+    where (oid,binEnc) = toPrepVal' (Proxy :: Proxy instncTy) x
 
-instance ToPrepArg Scientific where
-  toPrepVal = toPrepValHelper PTI.numeric PE.numeric
+type ArrEncInfo' a = (PTI.ArrOid, PTI.ElemOid, a -> PE.Array)
 
-instance ToPrepArg Char where
-  toPrepVal = toPrepValHelper PTI.text PE.char_utf8
+class ArrBinaryEnc' a (b :: InstanceTy) where
+  paaBinEncInfo :: Proxy b -> ArrEncInfo' a
 
-instance ToPrepArg T.Text where
-  toPrepVal = toPrepValHelper PTI.text PE.text_strict
+instance BinaryEncBuiltInTy a => ArrBinaryEnc' (V.Vector a) ('VectOf 'Elem) where
+  paaBinEncInfo _ = encElemArray
 
-instance ToPrepArg TL.Text where
-  toPrepVal = toPrepValHelper PTI.text PE.text_lazy
+instance BinaryEncBuiltInTy a => ArrBinaryEnc' [a] ('ArrOf 'Elem) where
+  paaBinEncInfo _ = encElemArray
 
-instance ToPrepArg B.ByteString where
-  toPrepVal = toPrepValHelper PTI.bytea PE.bytea_strict
+encElemArray :: (BinaryEncBuiltInTy a, Foldable t)
+  => (PTI.ArrOid, PTI.ElemOid, t a -> PE.Array)
+encElemArray =
+  ( arrOid
+  , oid
+  , PE.dimensionArray foldl' $ maybe PE.nullArray PE.encodingArray . paBinaryEnc
+  )
+  where
+    (oid, arrOid, paBinaryEnc) = btBinaryEncInfo
 
-instance ToPrepArg BL.ByteString where
-  toPrepVal = toPrepValHelper PTI.bytea PE.bytea_lazy
+instance
+  ( F a ~ instncTy
+  , ArrBinaryEnc' (V.Vector a) ('VectOf instncTy)
+  )
+  => ArrBinaryEnc' (V.Vector (V.Vector a)) ('VectOf ('VectOf instncTy)) where
+    paaBinEncInfo _ = encArrArray (Proxy :: Proxy ('VectOf instncTy))
 
-instance ToPrepArg LocalTime where
-  toPrepVal = toPrepValHelper PTI.timestamp PE.timestamp_int
+instance
+  ( F a ~ instncTy
+  , ArrBinaryEnc' [a] ('ArrOf instncTy)
+  )
+  => ArrBinaryEnc' [[a]] ('ArrOf ('ArrOf instncTy)) where
+    paaBinEncInfo _ = encArrArray (Proxy :: Proxy ('ArrOf instncTy))
 
-instance ToPrepArg UTCTime where
-  toPrepVal = toPrepValHelper PTI.timestamptz PE.timestamptz_int
+encArrArray
+  :: (ArrBinaryEnc' a b, Foldable t)
+  => Proxy b -> (PTI.ArrOid, PTI.ElemOid, t a -> PE.Array)
+encArrArray ty =
+      ( paaOid
+      , paaArrOid
+      , \x -> PE.dimensionArray foldl' paaBinaryEnc x
+      )
+      where
+        (paaOid, paaArrOid, paaBinaryEnc)
+           = paaBinEncInfo ty
 
-instance ToPrepArg Bool where
-  toPrepVal = toPrepValHelper PTI.bool PE.bool
+instance
+  ( F a ~ instncTy
+  , ArrBinaryEnc' (V.Vector a) ('VectOf instncTy)
+  )
+  => ToPrepArgBin' ('VectOf instncTy) (V.Vector a) where
+       toPrepVal' _  = arrToBinEnc (Proxy :: Proxy ('VectOf instncTy))
 
-instance ToPrepArg Day where
-  toPrepVal = toPrepValHelper PTI.date PE.date
+instance
+  ( F a ~ instncTy
+  , ArrBinaryEnc' [a] ('ArrOf instncTy)
+  )
+  => ToPrepArgBin' ('ArrOf instncTy) [a] where
+       toPrepVal' _  = arrToBinEnc (Proxy :: Proxy ('ArrOf instncTy))
+
+arrToBinEnc
+  :: ArrBinaryEnc' a b
+  => Proxy b
+  -> a
+  -> (PQ.Oid, Maybe PE.Encoding)
+arrToBinEnc ty x =
+  ( arrOid
+  , Just $ PE.array (toWord32 elemOid) (arrEncF x)
+  )
+  where
+    toWord32 (PQ.Oid (CUInt z)) = z
+    (PTI.ArrOid arrOid, PTI.ElemOid elemOid, arrEncF) = paaBinEncInfo ty
+
+type EncInfoBuiltInTy a = (PTI.ElemOid, PTI.ArrOid, a -> Maybe PE.Encoding)
+
+class BinaryEncBuiltInTy a where
+  btBinaryEncInfo :: EncInfoBuiltInTy a
+
+instance BinaryEncBuiltInTy a => ToPrepArgBin' 'Elem a where
+  toPrepVal' _ x
+    = ( PTI.getElemOid paOid, paBinaryEncM x)
+    where
+      (paOid, _, paBinaryEncM) = btBinaryEncInfo
+
+instance BinaryEncBuiltInTy a => BinaryEncBuiltInTy (Maybe a) where
+  btBinaryEncInfo =
+     ( paOid
+     , paArrOid
+     , (paBinaryEnc =<<)
+     )
+     where
+       (paOid,paArrOid,paBinaryEnc) = btBinaryEncInfo
+
+binEncHelper :: (PTI.ElemOid, PTI.ArrOid) -> (a -> PE.Encoding) -> EncInfoBuiltInTy a
+binEncHelper (elemOid,arrOid) f = (elemOid,arrOid,Just . f)
+
+instance (J.ToJSON a) => BinaryEncBuiltInTy (AltJ a) where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.json) $ \(AltJ x) -> PE.bytea_lazy $ J.encode x
+
+instance BinaryEncBuiltInTy Word64 where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.int8) PE.int8_word64
+  --toPrepVal = toPrepValHelper PTI.int8 PE.int8_word64
+
+instance BinaryEncBuiltInTy Int64 where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.int8) PE.int8_int64
+  --toPrepVal = toPrepValHelper PTI.int8 PE.int8_int64
+
+instance BinaryEncBuiltInTy Int32 where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.int4) PE.int4_int32
+  --toPrepVal = toPrepValHelper PTI.int4 PE.int4_int32
+
+instance BinaryEncBuiltInTy Int16 where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.int2) PE.int2_int16
+  --toPrepVal = toPrepValHelper PTI.int2 PE.int2_int16
+
+instance BinaryEncBuiltInTy Float where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.float4) PE.float4
+  --toPrepVal = toPrepValHelper PTI.float4 PE.float4
+
+instance BinaryEncBuiltInTy Double where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.float8) PE.float8
+  --toPrepVal = toPrepValHelper PTI.float8 PE.float8
+
+instance BinaryEncBuiltInTy Scientific where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.numeric) PE.numeric
+  --toPrepVal = toPrepValHelper PTI.numeric PE.numeric
+
+instance BinaryEncBuiltInTy Char where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.text) PE.char_utf8
+  --toPrepVal = toPrepValHelper PTI.text PE.char_utf8
+
+instance BinaryEncBuiltInTy T.Text where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.text) PE.text_strict
+  --toPrepVal = toPrepValHelper PTI.text PE.text_strict
+
+instance BinaryEncBuiltInTy TL.Text where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.text) PE.text_lazy
+  --toPrepVal = toPrepValHelper PTI.text PE.text_lazy
+
+instance BinaryEncBuiltInTy B.ByteString where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.bytea) PE.bytea_strict
+  --toPrepVal = toPrepValHelper PTI.bytea PE.bytea_strict
+
+instance BinaryEncBuiltInTy BL.ByteString where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.bytea) PE.bytea_lazy
+  --toPrepVal = toPrepValHelper PTI.bytea PE.bytea_lazy
+
+instance BinaryEncBuiltInTy LocalTime where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.timestamp) PE.timestamp_int
+  --toPrepVal = toPrepValHelper PTI.timestamp PE.timestamp_int
+
+instance BinaryEncBuiltInTy UTCTime where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.timestamptz) PE.timestamptz_int
+  --toPrepVal = toPrepValHelper PTI.timestamptz PE.timestamptz_int
+
+instance BinaryEncBuiltInTy Bool where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.bool) PE.bool
+  --toPrepVal = toPrepValHelper PTI.bool PE.bool
+
+instance BinaryEncBuiltInTy Day where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.date) PE.date
+  --toPrepVal = toPrepValHelper PTI.date PE.date
 
 newtype JSON  = JSON J.Value deriving (Eq, Show)
 newtype JSONB =  JSONB J.Value deriving (Eq, Show)
 
-instance ToPrepArg JSON where
-  toPrepVal (JSON j) = toPrepValHelper PTI.json PE.json_ast j
+instance BinaryEncBuiltInTy JSON where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.json) $ \(JSON j) -> PE.json_ast j
+  --toPrepVal (JSON j) = toPrepValHelper PTI.json PE.json_ast j
 
-instance ToPrepArg JSONB where
-  toPrepVal (JSONB j) = toPrepValHelper PTI.jsonb PE.jsonb_ast j
+instance BinaryEncBuiltInTy JSONB where
+  btBinaryEncInfo = binEncHelper $(PTI.arrOidsQ PTI.jsonb) $ \(JSONB j) -> PE.jsonb_ast j
+  --toPrepVal (JSONB j) = toPrepValHelper PTI.jsonb PE.jsonb_ast j
 
-instance (ToPrepArg a) => ToPrepArg (Maybe a) where
-  toPrepVal (Just a) = toPrepVal a
-  -- FIX ME, the oid here should be particular to the type
-  toPrepVal Nothing  = (PTI.auto, Nothing)
+--instance (ToPrepArg a) => ToPrepArg (Maybe a) where
+--  toPrepVal (Just a) = toPrepVal a
+--  -- FIX ME, the oid here should be particular to the type
+--  toPrepVal Nothing  = (PTI.auto, Nothing)
 
 instance (ToPrepArg a) => ToPrepArgs [a] where
   toPrepArgs = map toPrepVal

--- a/src/Database/PG/Query/PTI.hs
+++ b/src/Database/PG/Query/PTI.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE DeriveLift      #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module Database.PG.Query.PTI where
 
 import           Data.Word
 
-import qualified Database.PostgreSQL.LibPQ as PQ
+import           Data.Hashable
+import qualified Data.HashMap.Strict        as Map
+import           Data.Tuple
+import qualified Database.PostgreSQL.LibPQ  as PQ
+import           Foreign.C.Types
+import qualified Language.Haskell.TH.Syntax as TH
 
 mkOid :: Word32 -> PQ.Oid
 mkOid = PQ.Oid . fromIntegral
@@ -84,5 +91,173 @@ xid             = mkOid 28
 xml             = mkOid 142
 
 -- Array Types
+abstime_arr       = mkOid 1023
+aclitem_arr       = mkOid 1034
+bit_arr           = mkOid 1561
+bool_arr          = mkOid 1000
+box_arr           = mkOid 1020
+bpchar_arr        = mkOid 1014
+bytea_arr         = mkOid 1001
+char_arr          = mkOid 1002
+cid_arr           = mkOid 1012
+cidr_arr          = mkOid 651
+circle_arr        = mkOid 719
+cstring_arr       = mkOid 1263
+date_arr          = mkOid 1182
+daterange_arr     = mkOid 3913
+float4_arr        = mkOid 1021
+float8_arr        = mkOid 1022
+gtsvector_arr     = mkOid 3644
+inet_arr          = mkOid 1041
+int2_arr          = mkOid 1005
+int2vector_arr    = mkOid 1006
+int4_arr          = mkOid 1007
+int4range_arr     = mkOid 3905
+int8_arr          = mkOid 1016
+int8range_arr     = mkOid 3927
+interval_arr      = mkOid 1187
+json_arr          = mkOid 199
+jsonb_arr         = mkOid 3807
+line_arr          = mkOid 629
+lseg_arr          = mkOid 1018
+macaddr_arr       = mkOid 1040
+money_arr         = mkOid 791
+name_arr          = mkOid 1003
+numeric_arr       = mkOid 1231
+numrange_arr      = mkOid 3907
+oid_arr           = mkOid 1028
+oidvector_arr     = mkOid 1013
+path_arr          = mkOid 1019
+point_arr         = mkOid 1017
+polygon_arr       = mkOid 1027
+record_arr        = mkOid 2287
+refcursor_arr     = mkOid 2201
+regclass_arr      = mkOid 2210
+regconfig_arr     = mkOid 3735
+regdictionary_arr = mkOid 3770
+regoper_arr       = mkOid 2208
+regoperator_arr   = mkOid 2209
+regproc_arr       = mkOid 1008
+regprocedure_arr  = mkOid 2207
+regtype_arr       = mkOid 2211
+reltime_arr       = mkOid 1024
+text_arr          = mkOid 1009
+tid_arr           = mkOid 1010
+time_arr          = mkOid 1183
+timestamp_arr     = mkOid 1115
+timestamptz_arr   = mkOid 1185
+timetz_arr        = mkOid 1270
+tinterval_arr     = mkOid 1025
+tsquery_arr       = mkOid 3645
+tsrange_arr       = mkOid 3909
+tstzrange_arr     = mkOid 3911
+tsvector_arr      = mkOid 3643
+txid_snapshot_arr = mkOid 2949
+uuid_arr          = mkOid 2951
+varbit_arr        = mkOid 1563
+varchar_arr       = mkOid 1015
+xid_arr           = mkOid 1011
+xml_arr           = mkOid 143
 
-text_arr        = mkOid 1009
+newtype ElemOid = ElemOid { getElemOid :: PQ.Oid} deriving (Show, Eq)
+
+instance TH.Lift ElemOid where
+  lift (ElemOid (PQ.Oid (CUInt w)))
+    = [| ElemOid (PQ.Oid ( CUInt $(TH.lift w))) |]
+
+instance Hashable ElemOid where
+  hashWithSalt i (ElemOid (PQ.Oid (CUInt z))) = hashWithSalt i z
+
+newtype ArrOid  = ArrOid { getArrOid :: PQ.Oid} deriving (Show, Eq)
+
+instance TH.Lift ArrOid where
+  lift (ArrOid (PQ.Oid (CUInt w)))
+    = [| ArrOid (PQ.Oid ( CUInt $(TH.lift w))) |]
+
+instance Hashable ArrOid where
+  hashWithSalt i (ArrOid (PQ.Oid (CUInt z))) = hashWithSalt i z
+
+arrOidsQ :: PQ.Oid -> TH.Q TH.Exp
+arrOidsQ e = case getArrOidOfElem (ElemOid e) of
+  Nothing -> fail $ "Could not find array oid for " <> show e
+  Just x  -> TH.lift (ElemOid e, x)
+
+getArrOidOfElem :: ElemOid -> Maybe ArrOid
+getArrOidOfElem e = Map.lookup e elemArrOidMap
+
+elemArrOidMap :: Map.HashMap ElemOid ArrOid
+elemArrOidMap = Map.fromList elemArrOidPairs
+
+arrElemOidMap :: Map.HashMap ArrOid ElemOid
+arrElemOidMap = Map.fromList $ map swap elemArrOidPairs
+
+elemArrOidPairs :: [(ElemOid,ArrOid)]
+elemArrOidPairs =
+  [ (ElemOid abstime        , ArrOid abstime_arr      )
+  , (ElemOid aclitem        , ArrOid aclitem_arr      )
+  , (ElemOid bit            , ArrOid bit_arr          )
+  , (ElemOid bool           , ArrOid bool_arr         )
+  , (ElemOid box            , ArrOid box_arr          )
+  , (ElemOid bpchar         , ArrOid bpchar_arr       )
+  , (ElemOid bytea          , ArrOid bytea_arr        )
+  , (ElemOid char           , ArrOid char_arr         )
+  , (ElemOid cid            , ArrOid cid_arr          )
+  , (ElemOid cidr           , ArrOid cidr_arr         )
+  , (ElemOid circle         , ArrOid circle_arr       )
+  , (ElemOid cstring        , ArrOid cstring_arr      )
+  , (ElemOid date           , ArrOid date_arr         )
+  , (ElemOid daterange      , ArrOid daterange_arr    )
+  , (ElemOid float4         , ArrOid float4_arr       )
+  , (ElemOid float8         , ArrOid float8_arr       )
+  , (ElemOid gtsvector      , ArrOid gtsvector_arr    )
+  , (ElemOid inet           , ArrOid inet_arr         )
+  , (ElemOid int2           , ArrOid int2_arr         )
+  , (ElemOid int2vector     , ArrOid int2vector_arr   )
+  , (ElemOid int4           , ArrOid int4_arr         )
+  , (ElemOid int4range      , ArrOid int4range_arr    )
+  , (ElemOid int8           , ArrOid int8_arr         )
+  , (ElemOid int8range      , ArrOid int8range_arr    )
+  , (ElemOid interval       , ArrOid interval_arr     )
+  , (ElemOid json           , ArrOid json_arr         )
+  , (ElemOid jsonb          , ArrOid jsonb_arr        )
+  , (ElemOid line           , ArrOid line_arr         )
+  , (ElemOid lseg           , ArrOid lseg_arr         )
+  , (ElemOid macaddr        , ArrOid macaddr_arr      )
+  , (ElemOid money          , ArrOid money_arr        )
+  , (ElemOid name           , ArrOid name_arr         )
+  , (ElemOid numeric        , ArrOid numeric_arr      )
+  , (ElemOid numrange       , ArrOid numrange_arr     )
+  , (ElemOid oid            , ArrOid oid_arr          )
+  , (ElemOid oidvector      , ArrOid oidvector_arr    )
+  , (ElemOid path           , ArrOid path_arr         )
+  , (ElemOid point          , ArrOid point_arr        )
+  , (ElemOid polygon        , ArrOid polygon_arr      )
+  , (ElemOid record         , ArrOid record_arr       )
+  , (ElemOid refcursor      , ArrOid refcursor_arr    )
+  , (ElemOid regclass       , ArrOid regclass_arr     )
+  , (ElemOid regconfig      , ArrOid regconfig_arr    )
+  , (ElemOid regdictionary  , ArrOid regdictionary_arr)
+  , (ElemOid regoper        , ArrOid regoper_arr      )
+  , (ElemOid regoperator    , ArrOid regoperator_arr  )
+  , (ElemOid regproc        , ArrOid regproc_arr      )
+  , (ElemOid regprocedure   , ArrOid regprocedure_arr )
+  , (ElemOid regtype        , ArrOid regtype_arr      )
+  , (ElemOid reltime        , ArrOid reltime_arr      )
+  , (ElemOid text           , ArrOid text_arr         )
+  , (ElemOid tid            , ArrOid tid_arr          )
+  , (ElemOid time           , ArrOid time_arr         )
+  , (ElemOid timestamp      , ArrOid timestamp_arr    )
+  , (ElemOid timestamptz    , ArrOid timestamptz_arr  )
+  , (ElemOid timetz         , ArrOid timetz_arr       )
+  , (ElemOid tinterval      , ArrOid tinterval_arr    )
+  , (ElemOid tsquery        , ArrOid tsquery_arr      )
+  , (ElemOid tsrange        , ArrOid tsrange_arr      )
+  , (ElemOid tstzrange      , ArrOid tstzrange_arr    )
+  , (ElemOid tsvector       , ArrOid tsvector_arr     )
+  , (ElemOid txid_snapshot  , ArrOid txid_snapshot_arr)
+  , (ElemOid uuid           , ArrOid uuid_arr         )
+  , (ElemOid varbit         , ArrOid varbit_arr       )
+  , (ElemOid varchar        , ArrOid varchar_arr      )
+  , (ElemOid xid            , ArrOid xid_arr          )
+  , (ElemOid xml            , ArrOid xml_arr          )
+  ]


### PR DESCRIPTION
- Provides support for ToPrepArg([[..builtinTy]])