### PR TITLE
Support building on macOS

### DIFF
--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -48,7 +48,6 @@ library
                      , uuid >= 1.3
 
                      , postgresql-libpq
-                     , select
                      , retry
 
   default-language:    Haskell2010

--- a/src/Database/PG/Query.hs
+++ b/src/Database/PG/Query.hs
@@ -10,7 +10,8 @@ import           Database.PG.Query.Class
 import           Database.PG.Query.Connection  (ConnInfo (..), PGConn (..),
                                                 PGConnErr (..), PGLogEvent (..),
                                                 PGLogger, PrepArg,
-                                                ResultOk (..), Template)
+                                                ResultOk (..), Template,
+                                                pgConnString)
 import           Database.PG.Query.Listen
 import           Database.PG.Query.Pool
 import           Database.PG.Query.Transaction

--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -9,6 +9,7 @@ module Database.PG.Query.Connection
     ( initPQConn
     , defaultConnInfo
     , ConnInfo(..)
+    , pgConnString
     , PGQuery(..)
     , PGRetryPolicy
     , mkPGRetryPolicy
@@ -190,7 +191,7 @@ defaultConnInfo =
            , connRetries = 0
            }
 
-pgConnString :: ConnInfo -> DB.ByteString
+pgConnString :: IsString a => ConnInfo -> a
 pgConnString connInfo = fromString connstr
   where
     connstr = str "host="     connHost
@@ -259,8 +260,8 @@ retryOnConnErr pgConn action =
   pgRetrying resetFn retryP logger $ do
     resE <- lift $ runExceptT action
     case resE of
-      Right r -> return $ Right r
-      Left (Left pgIntErr) -> throwError pgIntErr
+      Right r                -> return $ Right r
+      Left (Left pgIntErr)   -> throwError pgIntErr
       Left (Right pgConnErr) -> return $ Left pgConnErr
   where
     resetFn = resetPGConn pgConn


### PR DESCRIPTION
This PR makes a small changes to allow this package to build on macOS as well as Linux. Specifically, it removes a dependency on the `select` package, using functionality provided by the GHC RTS instead.

Additionally, this also exports `pgConnString`, which is used in the related hasura/graphql-engine#2455.

Related to hasura/graphql-engine#2453.