### PR TITLE
Set extra_float_digits to 3 to avoid loss of precision

### DIFF
--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -177,6 +177,8 @@ initPQConn ci logger =
       mRes <- PQ.exec conn $ toByteString $ mconcat
               [ BB.string7 "SET client_encoding = 'UTF8';"
               , BB.string7 "SET client_min_messages TO WARNING;"
+              -- To avoid loss of precision in PostgreSQL 11 and older
+              , BB.string7 "SET extra_float_digits = 3;"
               ]
       case mRes of
         Just res -> do


### PR DESCRIPTION
The PostgreSQL manual recommends setting this whenever we want to avoid losing
precision of floats, see:

https://www.postgresql.org/docs/12/runtime-config-client.html#GUC-EXTRA-FLOAT-DIGITS
https://www.postgresql.org/docs/12/datatype-numeric.html#DATATYPE-FLOAT

This will end up fixing hasura/graphql-engine#5092