### PR TITLE
Revert "Set extra_float_digits to 3 to avoid loss of precision"

### DIFF
--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -177,8 +177,6 @@ initPQConn ci logger =
       mRes <- PQ.exec conn $ toByteString $ mconcat
               [ BB.string7 "SET client_encoding = 'UTF8';"
               , BB.string7 "SET client_min_messages TO WARNING;"
-              -- To avoid loss of precision in PostgreSQL 11 and older
-              , BB.string7 "SET extra_float_digits = 3;"
               ]
       case mRes of
         Just res -> do


### PR DESCRIPTION
This reverts commit 6b5443b8850586f67b5bc2af95635abe431075cd (merged in #17).

#17 implements an aborted development of a fix for hasura/graphql-engine#5092. As discussed in hasura/graphql-engine#5104, we will now rather fix hasura/graphql-engine#5092 by instructing users to either change their configuration or upgrade to Postgres 12 or later.