### PR TITLE
fix build error about missing postgres-fe.h

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -42,7 +42,12 @@ psqlBuildInfo lbi = do
                          (simpleProgram "pg_config") (withPrograms lbi)
   let pgconfig = getProgramOutput verbosity pgconfigProg
 
+  -- On Debian, --includedir and --pkgincludedir return the path
+  -- "/usr/include/postgresql" but on Arch Linux, they are respectively
+  -- "/usr/inculde" and "/usr/include/postgresql".  We need to have
+  -- "/usr/inculde/postgresql" as part of our includes for "internal/postgres_fe.h"
   incDir <- pgconfig ["--includedir"]
+  pkgIncDir <- pgconfig ["--pkgincludedir"]
   libDir <- pgconfig ["--libdir"]
   -- jberryman: this we need for libpq-int.h:
   cppflags <- pgconfig ["--cppflags"]
@@ -50,7 +55,7 @@ psqlBuildInfo lbi = do
 
   return emptyBuildInfo {
     extraLibDirs = [strip libDir],
-    includeDirs  = [strip incDir],
+    includeDirs  = [strip incDir, strip pkgIncDir],
     -- jberryman: added:
     ccOptions = words cppflags <> words cflags
   }


### PR DESCRIPTION
Fixes this error on Arch Linux and macOS X
```
error: In file included from ExtraBindings.hsc:12:
cbits/libpq-bindings.h:1:10: fatal error: internal/postgres_fe.h: No such file or directory
    1 | #include <internal/postgres_fe.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```