### PR TITLE
Check that buffer is available before freeing

### DIFF
--- a/cbits/libpq-bindings.c
+++ b/cbits/libpq-bindings.c
@@ -75,7 +75,7 @@ void PQclampInOutBufferSpace(PGconn *conn) {
      *
      * Just as above, but for the request buffer.
      */
-    if (conn->outCount == 0 && conn->outBufSize > maxSize * 2) {
+    if (conn->outBuffer && conn->outCount == 0 && conn->outBufSize > maxSize * 2) {
         free(conn->outBuffer);
         conn->outBuffer = malloc(maxSize);
         conn->outBufSize = maxSize;

--- a/cbits/libpq-bindings.c
+++ b/cbits/libpq-bindings.c
@@ -53,7 +53,7 @@ void PQclampInOutBufferSpace(PGconn *conn) {
      * committing a transaction, but is included for sanity. It's not clear if
      * this function is safe to call in other situation.
      */
-    if (conn->inStart == conn->inEnd && conn->inBufSize > maxSize * 2) {
+    if (conn->inBuffer && conn->inStart == conn->inEnd && conn->inBufSize > maxSize * 2) {
         /* NOTE: Operationally we think we want to shrink this buffer and free
          * pages from the tail (of what is, at this size, likely mmapped memory)
          * and so realloc() is tempting. But realloc might actually copy, even when


### PR DESCRIPTION
Currently a WIP as fix has not been verified on staging.

Segfault crash is occurring in staging environment with the following core dump backtrace:

```
[Current thread is 1 (Thread 0x7f10557fa700 (LWP 8561))]
(gdb) bt full
#0  __GI___libc_free (mem=0x183300000001) at malloc.c:3103
        ar_ptr = <optimized out>
        p = <optimized out>
        hook = 0x0
        mem = 0x183300000001
        ar_ptr = <optimized out>
        p = <optimized out>
        hook = <optimized out>
        __x = <optimized out>
        ar_ptr = <optimized out>
        p = <optimized out>
        hook = 0x0
        __x = <optimized out>
#1  0x00000000026ccea8 in PQclampInOutBufferSpace (conn=0x5b82cf0) at cbits/libpq-bindings.c:65
```

This is thrown from here: https://github.com/hasura/pg-client-hs/blob/master/cbits/libpq-bindings.c#L79

as documented in issue: https://github.com/hasura/graphql-engine-pro/issues/410

As per the implementation of `freePGconn` from libpq in pstgresql-12.3 the buffers should first be checked before freeing. This PR adds a buffer check.