### PR TITLE
Introducing transaction monad transformer `TxET`

### DIFF
--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -60,6 +60,7 @@ library
 
                      , postgresql-libpq
                      , retry
+                     , mmorph
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Database/PG/Query/Transaction.hs
+++ b/src/Database/PG/Query/Transaction.hs
@@ -12,8 +12,10 @@ module Database.PG.Query.Transaction
     , TxMode
     , PGTxErr(..)
     , getPGStmtErr
+    , TxET(..)
+    , TxE
+    , TxT
     , Tx
-    , TxE(..)
     , withNotices
     , withQ
     , withQE
@@ -41,8 +43,9 @@ import           Database.PG.Query.Connection
 
 import           Control.Monad.Base
 import           Control.Monad.Except
+import           Control.Monad.Morph          (hoist)
 import           Control.Monad.Reader
-import           Control.Monad.Trans.Control
+-- import           Control.Monad.Trans.Control
 import           Data.Aeson
 import           Data.Aeson.Text
 import           Data.Hashable
@@ -77,16 +80,25 @@ instance Show TxAccess where
 
 type TxMode = (TxIsolation, Maybe TxAccess)
 
-type Tx = TxE PGTxErr
+newtype TxET e m a
+  = TxET { txHandler :: ReaderT PGConn (ExceptT e m) a }
+  deriving ( Functor, Applicative, Monad, MonadError e, MonadIO, MonadReader PGConn)
+           -- , MonadBase IO, MonadBaseControl IO )
 
-newtype TxE e a
-  = TxE { txHandler :: ReaderT PGConn (ExceptT e IO) a }
-  deriving ( Functor, Applicative, Monad, MonadError e, MonadIO, MonadReader PGConn
-           , MonadBase IO, MonadBaseControl IO )
+instance MonadTrans (TxET e) where
+  lift = TxET . lift . lift
+
+instance (MonadBase IO m) => MonadBase IO (TxET e m) where
+  liftBase = lift . liftBase
+
+type TxE e a = TxET e IO a
+type TxT m a = TxET PGTxErr m a
+type Tx a = TxE PGTxErr a
+
 
 {-# INLINE catchE #-}
-catchE :: (e -> e') -> TxE e a -> TxE e' a
-catchE f action = TxE $ mapReaderT (withExceptT f) $ txHandler action
+catchE :: (Functor m) => (e -> e') -> TxET e m a -> TxET e' m a
+catchE f action = TxET $ mapReaderT (withExceptT f) $ txHandler action
 
 data PGTxErr
   = PGTxErr !T.Text ![PrepArg] !Bool !PGErrInternal
@@ -111,7 +123,7 @@ instance Show PGTxErr where
   show = show . encodeToLazyText
 
 {-# INLINE execTx #-}
-execTx :: PGConn -> TxE e a -> ExceptT e IO a
+execTx :: PGConn -> TxET e m a -> ExceptT e m a
 execTx conn tx = runReaderT (txHandler tx) conn
 
 newtype Query
@@ -126,61 +138,61 @@ fromText = Query
 fromBuilder :: TB.Builder -> Query
 fromBuilder = Query . TB.run
 
-withQ :: (FromRes a, ToPrepArgs r)
+withQ :: (MonadIO m, FromRes a, ToPrepArgs r)
       => Query
       -> r
       -> Bool
-      -> Tx a
+      -> TxT m a
 withQ = withQE id
 
-withQE :: (FromRes a, ToPrepArgs r)
+withQE :: (MonadIO m, FromRes a, ToPrepArgs r)
        => (PGTxErr -> e)
        -> Query
        -> r
        -> Bool
-       -> TxE e a
+       -> TxET e m a
 withQE ef q r prep =
   rawQE ef q args prep
   where
     args = toPrepArgs r
 
-rawQ :: (FromRes a)
+rawQ :: (MonadIO m, FromRes a)
      => Query
      -> [PrepArg]
      -> Bool
-     -> Tx a
+     -> TxT m a
 rawQ = rawQE id
 
-rawQE :: (FromRes a)
+rawQE :: (MonadIO m, FromRes a)
       => (PGTxErr -> e)
       -> Query
       -> [PrepArg]
       -> Bool
-      -> TxE e a
-rawQE ef q args prep = TxE $ ReaderT $ \pgConn ->
-  withExceptT (ef . txErrF) $
+      -> TxET e m a
+rawQE ef q args prep = TxET $ ReaderT $ \pgConn ->
+  withExceptT (ef . txErrF) $ (hoist liftIO) $
   execQuery pgConn $ PGQuery (mkTemplate stmt) args prep fromRes
   where
     txErrF = PGTxErr stmt args prep
     stmt = getQueryText q
 
-multiQE :: (FromRes a)
+multiQE :: (MonadIO m, FromRes a)
         => (PGTxErr -> e)
         -> Query
-        -> TxE e a
-multiQE ef q = TxE $ ReaderT $ \pgConn ->
-  withExceptT (ef . txErrF) $
+        -> TxET e m a
+multiQE ef q = TxET $ ReaderT $ \pgConn ->
+  withExceptT (ef . txErrF) $ (hoist liftIO) $
   execMulti pgConn (mkTemplate stmt) fromRes
   where
     txErrF = PGTxErr stmt [] False
     stmt = getQueryText q
 
-multiQ :: (FromRes a)
+multiQ :: (MonadIO m, FromRes a)
        => Query
-       -> Tx a
+       -> TxT m a
 multiQ = multiQE id
 
-withNotices :: Tx a -> Tx (a, [T.Text])
+withNotices :: (MonadIO m) => TxT m a -> TxT m (a, [T.Text])
 withNotices tx =  do
   conn <- asks pgPQConn
   setToNotice
@@ -199,57 +211,57 @@ withNotices tx =  do
         Nothing -> return xs
         Just bs -> getNotices conn (bs:xs)
 
-unitQ :: (ToPrepArgs r)
+unitQ :: (MonadIO m, ToPrepArgs r)
       => Query
       -> r
       -> Bool
-      -> Tx ()
+      -> TxT m ()
 unitQ = withQ
 
-unitQE :: (ToPrepArgs r)
+unitQE :: (MonadIO m, ToPrepArgs r)
        => (PGTxErr -> e)
        -> Query
        -> r
        -> Bool
-       -> TxE e ()
+       -> TxET e m ()
 unitQE = withQE
 
-discardQ :: (ToPrepArgs r)
+discardQ :: (MonadIO m, ToPrepArgs r)
          => Query
          -> r
          -> Bool
-         -> Tx ()
+         -> TxT m ()
 discardQ t r p= do
   Discard () <- withQ t r p
   return ()
 
-discardQE :: (ToPrepArgs r)
+discardQE :: (MonadIO m, ToPrepArgs r)
           => (PGTxErr -> e)
           -> Query
           -> r
           -> Bool
-          -> TxE e ()
+          -> TxET e m ()
 discardQE ef t r p= do
   Discard () <- withQE ef t r p
   return ()
 
-listQ :: (FromRow a, ToPrepArgs r)
+listQ :: (MonadIO m, FromRow a, ToPrepArgs r)
       => Query
       -> r
       -> Bool
-      -> Tx [a]
+      -> TxT m [a]
 listQ = withQ
 
-listQE :: (FromRow a, ToPrepArgs r)
+listQE :: (MonadIO m, FromRow a, ToPrepArgs r)
        => (PGTxErr -> e)
        -> Query
        -> r
        -> Bool
-       -> TxE e [a]
+       -> TxET e m [a]
 listQE = withQE
 
 serverVersion
-  :: TxE e Int
+  :: MonadIO m => TxET e m Int
 serverVersion = do
   conn <- asks pgPQConn
   liftIO $ PQ.serverVersion conn


### PR DESCRIPTION
Earlier `TxE e a` monad is bound to `IO a` as base monad. This PR introducing `TxET e m a` monad transformer with `m a` as any base monad.