### PR TITLE
Remove libpq buffer shrinking, effectively reverting fbb635023

### DIFF
--- a/cbits/libpq-bindings.c
+++ b/cbits/libpq-bindings.c
@@ -7,6 +7,11 @@
 
 #define ONE_MEGABYTE (1024*1024)
 
+/* FIXME
+ *   We're getting segfaults here (see FIXME below). Discussion
+ *     https://hasurahq.slack.com/archives/CV3UR1MT2/p1605084695393300 
+ */
+
 /* 
  * libpq grows the buffers it uses for input and output, as needed,
  * exponentially, but it never shrinks them. This means that if we try to keep
@@ -62,7 +67,7 @@ void PQclampInOutBufferSpace(PGconn *conn) {
          * so trust our malloc implementation to handle this case in the most
          * efficient way.
          */
-        free(conn->inBuffer);
+        free(conn->inBuffer); /* FIXME (see above) */
         conn->inBuffer = malloc(maxSize);
         conn->inBufSize = maxSize;
         if (conn->inBuffer == NULL) {

--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -30,7 +30,7 @@ module Database.PG.Query.Pool
   , PGConnectionStale(..)
   ) where
 
-import           Database.PG.ExtraBindings
+-- import           Database.PG.ExtraBindings
 import           Database.PG.Query.Connection
 import           Database.PG.Query.Transaction
 
@@ -243,8 +243,9 @@ withExpiringPGconn pool f = do
         throw PGConnectionStale
       -- else proceed with callback:
       f connRsrc
+        -- FIXME this segfaults sometimes... see cbits/libpq-bindings.c
         -- Clean up the connection buffers to prevent memory bloat (See #5087):
-        <* liftIO (unsafeClampInOutBufferSpace pgPQConn)
+        -- <* liftIO (unsafeClampInOutBufferSpace pgPQConn)
 
 -- | Used internally (see 'withExpiringPGconn'), but exported in case we need
 -- to allow callback to signal that the connection should be destroyed and we


### PR DESCRIPTION
We're unfortunately getting segfaults occasionally. The plan is to rely
on discarding connections periodically for now.