### PR TITLE
add connection acquisition timeout exception

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/hasura/pool.git
-  tag: 0fdfaed4e109ca6a6bf00ed6d79c329626e3bdd4
+  tag: c48c89f0f4a9e424103d4004a8c59ca9318c88ed

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/hasura/pool.git
-  tag: 426409655f1413fa408ec58abc5e1db567c31a34
+  tag: bc4c3f739a8fb8ec4444336a34662895831c9acf

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/hasura/pool.git
-  tag: c48c89f0f4a9e424103d4004a8c59ca9318c88ed
+  tag: 426409655f1413fa408ec58abc5e1db567c31a34

--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -78,6 +78,9 @@ test-suite pg-client-test
   main-is:             Spec.hs
   build-depends:       base
                      , pg-client
+                     , bytestring >= 0.10
+                     , hspec
+                     , mtl
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,107 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main (main) where
+
+import           Test.Hspec
+
+import           Database.PG.Query
+
+import           Control.Concurrent     (forkIO, threadDelay)
+import           Control.Exception      (Exception (fromException))
+import           Control.Exception.Base (IOException, SomeException)
+import           Control.Monad.Except   (ExceptT, MonadTrans (lift), runExceptT)
+
+import qualified Data.ByteString.Char8  as BS
+import qualified System.Environment     as Env
+
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = hspec $ do
+  describe "acquiring connections" do
+    it "acquire a single available resource" do
+      simpleTest `shouldReturn` Nothing
+    it "error when no connections available" do
+      noConnectionAvailable `shouldReturn` Nothing
+    it "release and acquire works correctly" do
+      releaseAndAcquire `shouldReturn` Nothing
+    it "release and acquire works correctly" do
+      releaseAndAcquireWithTimeout `shouldReturn` Nothing
+    it "time out works correctly" do
+      releaseAndAcquireWithTimeoutNegative `shouldReturn` Nothing
+
+mkPool :: IO PGPool
+mkPool = do
+  dbUri <- BS.pack <$> Env.getEnv "DATABASE_URL"
+  initPGPool (connInfo dbUri) connParams logger
+  where
+    connInfo uri = ConnInfo { ciRetries, ciDetails = mkDetails uri }
+    ciRetries = 0
+    mkDetails = CDDatabaseURI
+    logger = mempty
+    connParams = ConnParams 1 1 60 True Nothing (Just 3)
+
+withFreshPool :: (FromPGTxErr e, FromPGConnErr e) => PGPool -> IO a -> IO (Either e a)
+withFreshPool pool action =
+  runExceptT
+    . withConn pool (ReadCommitted, Just ReadOnly)
+    . const $ lift action
+
+err :: Show a => a -> IO (Maybe String)
+err = pure . Just . show
+
+nada :: IO ()
+nada = mempty
+
+simpleTest :: IO (Maybe String)
+simpleTest = do
+  pool <- mkPool
+  withFreshPool pool nada >>= \case
+    Left (e :: PGExecErr) -> err e
+    Right _               -> mempty
+
+noConnectionAvailable :: IO (Maybe String)
+noConnectionAvailable = do
+  pool <- mkPool
+  withFreshPool pool (action pool) >>= \case
+    Left (e :: PGExecErr) -> err e
+    Right _               -> mempty
+  where
+    action pool = withFreshPool pool nada >>= \case
+      Left (e :: PGExecErr) -> mempty
+      Right _               -> err "connection acquisition expected to fail"
+
+releaseAndAcquire :: IO (Maybe String)
+releaseAndAcquire = do
+  pool <- mkPool
+  _ <- withFreshPool pool nada >>= \case
+    Left (e :: PGExecErr) -> err e
+    Right _               -> mempty
+  withFreshPool pool nada >>= \case
+    Left (e :: PGExecErr) -> err e
+    Right _               -> mempty
+
+releaseAndAcquireWithTimeout :: IO (Maybe String)
+releaseAndAcquireWithTimeout = do
+  pool <- mkPool
+  _ <- forkIO $ withFreshPool pool (threadDelay 300_000) >>= \case
+    Left (e :: PGExecErr) -> error "unexpected error when acquiring connections"
+    Right _               -> mempty
+  threadDelay 100_000
+  withFreshPool pool nada >>= \case
+    Left (e :: PGExecErr) -> err e
+    Right _               -> mempty
+
+releaseAndAcquireWithTimeoutNegative :: IO (Maybe String)
+releaseAndAcquireWithTimeoutNegative = do
+  pool <- mkPool
+  _ <- forkIO $ withFreshPool pool (threadDelay 10_000_000) >>= \case
+    Left (e :: PGExecErr) -> error "unexpected error when acquiring connections"
+    Right _               -> mempty
+  threadDelay 1_000_000
+  withFreshPool pool nada >>= \case
+    Left (e :: PGExecErr) -> mempty
+    Right _               -> err "Wat"
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -18,6 +18,17 @@ import           Control.Monad.Except   (ExceptT, MonadTrans (lift), runExceptT)
 import qualified Data.ByteString.Char8  as BS
 import qualified System.Environment     as Env
 
+{- Note [Running tests]
+~~~~~~~~~~~~~~~~~~~~~~~
+The tests in this module expect a postgres instance running. No setup is
+required, these tests do not run any query on the database. The only requirement
+is that the environment variable DATABASE_URL is set such that it is a valid
+connection string to this instance (e.g.
+"postgres://user:pass@127.0.0.1:5432/instance?sslmode=disable").
+
+TODO: run these tests as part of CI.
+-}
+
 main :: IO ()
 main = hspec $ do
   describe "acquiring connections" do


### PR DESCRIPTION
This PR is the next iteration of #28.

The reason we moved from returning an explicit failure via `Maybe` to an exception is backwards compatibility with `pool`.

This PR also adds a few tests which have a catch: they require an active Postgres instance and an environment variable `DATABASE_URL` which is usable as a connection string to the instance. Since this only tests the connection pool, we don't actually run any queries/statements on the instance.

See hasura/pool#2 for details.