### PR TITLE
Refactor of 'listen', in prep for upstream refactor

### DIFF
--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -137,6 +137,14 @@ class FromPGTxErr e where
 class FromPGConnErr e where
   fromPGConnErr :: PGConnErr -> e
 
+-- These instances permit (FromPGConnErr e, MonadError e m)=> ... to unify with IO
+instance FromPGTxErr IOException where
+  fromPGTxErr = userError . show
+
+instance FromPGConnErr IOException where
+  fromPGConnErr = userError . show
+
+
 runTxOnConn :: (MonadIO m, FromPGTxErr e)
             => PGConn
             -> TxMode


### PR DESCRIPTION
This simplifies and improves documentation:

- take two separate callbacks for message processing and start
  signalling (makes things easier to document, and call-site more clear
- make return type `m void` to clarify that this is a loop, and allow us
  to use it with forkImmortal
- add instances that let us instantiate `listen` to IO