### PR TITLE
Emit logs when conn pool is nearing saturation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/hasura/pool.git
-  tag: bc4c3f739a8fb8ec4444336a34662895831c9acf
+  tag: 3bb41e10f143e50e9fd9f0ff2f04875eac9949ca

--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -97,8 +97,8 @@ instance ToJSON PGExecStatus where
 type PGRetryPolicyM m = CR.RetryPolicyM m
 type PGRetryPolicy = PGRetryPolicyM (ExceptT PGErrInternal IO)
 
-newtype PGLogEvent
-  = PLERetryMsg DT.Text
+data PGLogEvent
+  = PLERetryMsg DT.Text | PLEWarnMsg DT.Text 
   deriving (Show, Eq)
 
 type PGLogger = PGLogEvent -> IO ()
@@ -396,14 +396,14 @@ mkPGRetryPolicy noRetries =
 
 data PGConn
   = PGConn
-  { pgPQConn       :: !PQ.Connection
-  , pgAllowPrepare :: !Bool
-  , pgRetryPolicy  :: !PGRetryPolicy
-  , pgLogger       :: !PGLogger
-  , pgCounter      :: !(IORef Word16)
-  , pgTable        :: !RKLookupTable
-  , pgCreatedAt   :: !UTCTime
-  , pgMbLifetime   :: !(Maybe NominalDiffTime)
+  { pgPQConn        :: !PQ.Connection
+  , pgAllowPrepare  :: !Bool
+  , pgRetryPolicy   :: !PGRetryPolicy
+  , pgLogger        :: !PGLogger
+  , pgCounter       :: !(IORef Word16)
+  , pgTable         :: !RKLookupTable
+  , pgCreatedAt     :: !UTCTime
+  , pgMbLifetime    :: !(Maybe NominalDiffTime)
   -- ^ If passed, 'withExpiringPGconn' will destroy the connection when it is older than lifetime.
   }
 


### PR DESCRIPTION
- [x] Emit logs when connection pool is nearing saturation

#### TODO:

- [ ] Emit logs when connection pool is saturated

#### Related PR's:
1. [pool](https://github.com/hasura/pool/pull/4)

Closes:
https://github.com/hasura/graphql-engine-mono/issues/553