### PR TITLE
Prefer explicit UTF-8 decoding in TH file parser

### DIFF
--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -54,7 +54,7 @@ import           GHC.Generics
 import qualified Control.Retry                as CR
 import qualified Data.ByteString              as DB
 import qualified Data.ByteString.Lazy         as BL
-import qualified Data.ByteString.Lazy.Builder as BB
+import qualified Data.ByteString.Builder      as BB
 import qualified Data.HashTable.IO            as HI
 import qualified Data.Text                    as DT
 import qualified Data.Text.Encoding           as TE

--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -33,8 +33,13 @@ module Database.PG.Query.Pool
   , PGConnectionStale(..)
   ) where
 
-import           Database.PG.Query.Connection
-import           Database.PG.Query.Transaction
+import qualified Data.ByteString               as BS
+import qualified Data.HashTable.IO             as HI
+import qualified Data.Pool                     as RP
+import qualified Data.Text                     as T
+import qualified Data.Text.Encoding            as TE
+import qualified Database.PostgreSQL.LibPQ     as PQ
+import qualified System.Metrics.Distribution   as EKG.Distribution
 
 import           Control.Exception
 import           Control.Monad.Except
@@ -42,18 +47,13 @@ import           Control.Monad.Trans.Control
 import           Data.Aeson
 import           Data.IORef
 import           Data.Time
-import           GHC.Exts                      (fromString)
+import           GHC.Exts                    (fromString)
 import           Language.Haskell.TH.Quote
 import           Language.Haskell.TH.Syntax
+import           System.Metrics.Distribution (Distribution)
 
-import qualified Data.ByteString               as BS
-import qualified Data.HashTable.IO             as HI
-import qualified Data.Pool                     as RP
-import qualified Data.Text                     as T
-import qualified Data.Text.Encoding            as TE
-import qualified Database.PostgreSQL.LibPQ     as PQ
-import System.Metrics.Distribution (Distribution)
-import qualified System.Metrics.Distribution as EKG.Distribution
+import           Database.PG.Query.Connection
+import           Database.PG.Query.Transaction
 
 data PGPool = PGPool
   { -- | the underlying connection pool

--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -33,7 +33,6 @@ module Database.PG.Query.Pool
   , PGConnectionStale(..)
   ) where
 
--- import           Database.PG.ExtraBindings
 import           Database.PG.Query.Connection
 import           Database.PG.Query.Transaction
 

--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -46,9 +46,11 @@ import           GHC.Exts                      (fromString)
 import           Language.Haskell.TH.Quote
 import           Language.Haskell.TH.Syntax
 
+import qualified Data.ByteString               as BS
 import qualified Data.HashTable.IO             as HI
 import qualified Data.Pool                     as RP
 import qualified Data.Text                     as T
+import qualified Data.Text.Encoding            as TE
 import qualified Database.PostgreSQL.LibPQ     as PQ
 import System.Metrics.Distribution (Distribution)
 import qualified System.Metrics.Distribution as EKG.Distribution
@@ -259,11 +261,18 @@ runTxOnConn' = execTx
 sql :: QuasiQuoter
 sql = QuasiQuoter { quoteExp = \a -> [|fromString a|] }
 
+-- | Construct a 'Query' at compile-time from some given file.
+--
+-- NOTE: This function assumes that the file is UTF-8 encoded.
+--
+-- Any incompatible character encodings will be rejected at compile-time with
+-- a 'TE.UnicodeException' error.
 sqlFromFile :: FilePath -> Q Exp
 sqlFromFile fp = do
-  contents <- qAddDependentFile fp >> runIO (readFile fp)
-  [| fromString contents |]
-
+  bytes <- qAddDependentFile fp >> runIO (BS.readFile fp)
+  case TE.decodeUtf8' bytes of
+    Left err -> throw $! err
+    Right contents -> [| fromText contents |]
 
 -- | 'RP.withResource' for PGPool but implementing a workaround for #5087,
 -- optionally expiring the connection after a configurable amount of time so


### PR DESCRIPTION
Pretty much everything useful is in 0fae3bf's commit message:
```
The built-in 'readFile' function uses the system locale when determining
how to convert the input bytes to a Haskell 'String', which can be a
source of annoying and difficult to track down issues with respect to
character encoding.

Instead, it's safer to make the assumption that UTF-8 is the most
commonly used encoding scheme and reject all non-UTF-8 input as invalid
at compile-time whenever the 'sqlFromFile' splice is invoked.
```

---

It works as follows when run locally with `echo 'CREATE DATABASE;' > test.sql` and `/bin/sh` present:

```
Prelude Database.PG.Query> :set -XTemplateHaskell
Prelude Database.PG.Query>
Prelude Database.PG.Query> $(sqlFromFile "./test.sql")
Query {getQueryText = "CREATE DATABASE;\n"}
Prelude Database.PG.Query>
Prelude Database.PG.Query> $(sqlFromFile "/bin/sh")

<interactive>:3:1: error:
    • Exception when trying to run compile-time code:
        Cannot decode byte '\xdb': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream
      Code: sqlFromFile "/bin/sh"
    • In the untyped splice: $(sqlFromFile "/bin/sh")
```