### PR TITLE
Tries to fix 'Lift' instance propagation for 'Query'

### DIFF
--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -41,8 +41,6 @@ library
                      , hashable >= 1.2
                      , postgresql-binary
                      , template-haskell >= 2.11
-                     , th-lift >= 0.7
-                     , th-lift-instances >= 0.1
                      , ekg-core
 
                      , mtl

--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -47,10 +47,10 @@ import           Control.Monad.Trans.Control
 import           Data.Aeson
 import           Data.IORef
 import           Data.Time
-import           GHC.Exts                    (fromString)
+import           GHC.Exts                      (fromString)
 import           Language.Haskell.TH.Quote
 import           Language.Haskell.TH.Syntax
-import           System.Metrics.Distribution (Distribution)
+import           System.Metrics.Distribution   (Distribution)
 
 import           Database.PG.Query.Connection
 import           Database.PG.Query.Transaction

--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -272,7 +272,11 @@ sqlFromFile fp = do
   bytes <- qAddDependentFile fp >> runIO (BS.readFile fp)
   case TE.decodeUtf8' bytes of
     Left err -> throw $! err
-    Right contents -> [| fromText contents |]
+    Right txtContents ->
+      -- NOTE: This is (effectively) the same implementation as the 'Lift'
+      -- instance for 'Text' from 'th-lift-instances'.
+      let strContents = T.unpack txtContents
+      in [| fromText . T.pack $ strContents |]
 
 -- | 'RP.withResource' for PGPool but implementing a workaround for #5087,
 -- optionally expiring the connection after a configurable amount of time so


### PR DESCRIPTION
First, some context from 44da7ba's message:
```
The 'Lift' instance propagation for 'Text interacts strangely between
'pg-client-hs' and 'graphql-engine'.

This project compiles successfully (locally) without this change,
however the 'Lift' instance for 'Text' fails to propagate when it's used
within 'graphql-engine'.

Rather than trying to juggle the orphan instance exported by
'th-lift-instances', it seems easier to just do the same thing that it
does (i.e. unpack 'Text' to 'String' before lifting).
```

---

Honestly I'm pretty confused about what's going on here; when I compiled 0fae3bf9daad198e774ac6483c8ba552a4d19fc5 locally and tested it in my REPL everything seemed to work, but when I compiled it as a dependency of `graphql-engine` it started failing with an error stating that there was no `Lift` instance for `Text`.

If I were to guess, I'd say that somehow `th-lift-instances` was being brought into scope in my REPL session but was _not_ propagated when the modules were brought into scope within `graphql-engine`. It actually seems like `th-lift` and `th-lift-instances` aren't being used within this project at all?

---

So there seem to be two ways to handle this:
1. Avoid the `th-lift-instances` orphans entirely by converting `Text -> String` and using `fromString :: String -> Query` to construct the `Query` in the splice
    - This is what I've implemented in 44da7ba
2. Properly pull in `Instances.TH.Lift` within `Database.PG.Query.Transaction` and ensure that the `Lift` instance for `Text` is propagated such that `graphql-engine` picks it up
    - In this case I'm not too worried about orphan instance weirdness since we control the main project which consumes this library
    - That being said, [packdeps seems to indicate](https://packdeps.haskellers.com/reverse/th-lift-instances) that this library isn't actually as widely used as I would have thought