### PR TITLE
Support for timing out / cancelling queries

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -78,7 +78,7 @@ getPoolC = do
               Q.connOptions = Nothing
             }
       connInfo = Q.ConnInfo 0 connDetails
-      connParams = Q.ConnParams 1 1 180 False Nothing Nothing
+      connParams = Q.ConnParams 1 1 180 False Nothing Nothing False
       logger = const (return ())
   Q.initPGPool connInfo connParams logger
 

--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -28,6 +28,7 @@ library
                      , Database.PG.Query.Transaction
                      , Database.PG.Query.Pool
                      , Database.PG.Query.Listen
+                     , Control.Concurrent.Interrupt
 
   build-depends:       base >= 4.7 && < 5
                      , attoparsec >= 0.13
@@ -55,6 +56,8 @@ library
                      , postgresql-libpq
                      , retry
                      , mmorph
+                     , async
+                     , safe-exceptions
 
   ghc-options:         -Wall
 
@@ -63,11 +66,15 @@ test-suite pg-client-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
+  other-modules:       Interrupt
   build-depends:       base
                      , pg-client
                      , bytestring >= 0.10
                      , hspec
                      , mtl
+                     , time
+                     , async
+                     , safe-exceptions
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
 
 benchmark pg-client-bench

--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -67,6 +67,7 @@ test-suite pg-client-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   other-modules:       Interrupt
+                     , Timeout
   build-depends:       base
                      , pg-client
                      , bytestring >= 0.10

--- a/src/Control/Concurrent/Interrupt.hs
+++ b/src/Control/Concurrent/Interrupt.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Control.Concurrent.Interrupt
+  ( interruptOnAsyncException,
+  )
+where
+
+import Control.Concurrent.Async (async, asyncThreadId, wait, waitCatch)
+import Control.Exception
+  ( SomeAsyncException,
+    SomeException,
+    mask,
+    throwIO,
+    throwTo,
+    try,
+  )
+
+-- | interruptOnAsyncexception runs the given action in in a separate thread,
+-- running the given cancel action before passing on any asynchronous
+-- exceptions to that thread. The intent is that
+--   'interruptOnAsyncException (pure ()) == id'
+-- in all respects (including exception handling), assuming the wrapped
+-- action behaves somewhat reasonably (i.e., doesn't swallow asynchronous
+-- exceptions). Particularly, we guarantee that the separate thread terminates
+-- before we return. (It's not entirely transparent: for instance, 'myThreadId'
+-- returns a different value.)
+--
+-- The point of this is to allow breaking out of blocking actions if they
+-- provide some cancelling escape hatch.
+interruptOnAsyncException :: IO () -> IO a -> IO a
+interruptOnAsyncException interrupt action = mask $ \restore -> do
+  x <- async action
+
+  -- By using 'try' with 'waitCatch', we can distinguish between asynchronous
+  -- exceptions received from the outside, and those thrown by the wrapped action.
+  -- (The latter shouldn't occur, but we also want to avoid throwing an exception
+  -- back at the thread below.)
+  res :: Either SomeAsyncException (Either SomeException a) <-
+    try $ restore (waitCatch x)
+  case res of
+    -- Due to the use of 'waitCatch' above, the only exceptions that 'tryAsync'
+    -- might catch are asynchronous exceptions received from the "outside".
+    -- Thus, the 'Left' case is the only one where the async action has not
+    -- necessarily terminated.
+    Left e -> do
+      -- Cancelling might throw an exception; we save that and re-raise it,
+      -- but not before doing or job of passing the asynchronous exception on
+      -- to our child and waiting for it to terminate.
+      interruptRes :: Either SomeException () <- try $ interrupt
+      throwTo (asyncThreadId x) e
+      waitRes :: Either SomeException a <- try $ wait x
+      case (interruptRes, waitRes) of
+        (Left cancelEx, _) -> throwIO cancelEx
+        -- waitEx could be an exception thrown by the action, or our async
+        -- exception bubbling back up
+        (Right _, Left waitEx) -> throwIO waitEx
+        -- in case the async exits cleanly before receiving the exception, we
+        -- re-raise it manually so as to not swallow it, since the action
+        -- /was/ interrupted
+        (Right _, Right _) -> throwIO e
+
+    -- In the non-interrupted case, we "undo" the 'try', collapsing things
+    -- effectively to 'restore (wait x)'.
+    Right (Left e) ->
+      throwIO e
+    Right (Right r) ->
+      pure r

--- a/test/Interrupt.hs
+++ b/test/Interrupt.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Interrupt (specInterrupt) where
+
+import Control.Concurrent
+  ( MVar,
+    newEmptyMVar,
+    putMVar,
+    threadDelay,
+    tryReadMVar,
+  )
+import Control.Concurrent.Interrupt (interruptOnAsyncException)
+import Control.Exception.Safe
+import Control.Monad (liftM2, when)
+import Data.IORef
+import Data.Time (NominalDiffTime, diffUTCTime, getCurrentTime)
+import System.Timeout (timeout)
+import Test.Hspec
+import Prelude hiding (log)
+
+specInterrupt :: Spec
+specInterrupt = do
+  describe "without interrupt" $ do
+    it "logging etc works" $ do
+      events <- withLogger $ \log -> do
+        let action = trace log "sleep" $ sleep (1000 * ms)
+        res <- timeout (500 * ms) action
+        log "done"
+        res `shouldBe` Nothing
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "sleep start"),
+                     (500 * ms, "sleep exception"),
+                     (500 * ms, "done")
+                   ]
+    it "cancellable sleep is like sleep without cancelling" $ do
+      events <- withLogger $ \log -> do
+        let action = trace log "sleep" $ cancellableSleep (1000 * ms) (pure False)
+        res <- timeout (500 * ms) action
+        log "done"
+        res `shouldBe` Nothing
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "sleep start"),
+                     (500 * ms, "sleep exception"),
+                     (500 * ms, "done")
+                   ]
+    it "uninterruptible sleep doesn't time out" $ do
+      events <- withLogger $ \log -> do
+        let action = trace log "outer" $ do
+              uninterruptibleMask_ $ trace log "sleep" $ cancellableSleep (1000 * ms) (pure False)
+              -- add an extra action so the timeout is delivered reliably
+              sleep (500 * ms)
+        res <- timeout (500 * ms) action
+        log "done"
+        res `shouldBe` Nothing
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "outer start"),
+                     (0, "sleep start"),
+                     (1000 * ms, "sleep end"),
+                     (1000 * ms, "outer exception"),
+                     (1000 * ms, "done")
+                   ]
+
+  describe "interruptOnAsyncException" $ do
+    it "behaves like baseline without cancelling" $ do
+      events <- withLogger $ \log -> do
+        let action = interruptOnAsyncException (pure ()) $ trace log "sleep" $ sleep (1000 * ms)
+        res <- timeout (500 * ms) action
+        log "done"
+        res `shouldBe` Nothing
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "sleep start"),
+                     (500 * ms, "sleep exception"),
+                     (500 * ms, "done")
+                   ]
+    it "allows interrupting a blocking action" $ do
+      (cancel, cancelled) <- getCancel
+      events <- withLogger $ \log -> do
+        let action = trace log "outer" $ do
+              interruptOnAsyncException cancel $ uninterruptibleMask_ $ trace log "sleep" $ cancellableSleep (1000 * ms) cancelled
+        res <- timeout (500 * ms) action
+        log "done"
+        res `shouldBe` Nothing
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "outer start"),
+                     (0, "sleep start"),
+                     (500 * ms, "sleep end"),
+                     (500 * ms, "outer exception"),
+                     (500 * ms, "done")
+                   ]
+    it "waits for the thread and bubbles the exception if cancel only throws" $ do
+      (_cancel, cancelled) <- getCancel
+      let cancel = throwIO CancelException
+      events <- withLogger $ \log -> do
+        let action = trace log "outer" $ do
+              interruptOnAsyncException cancel $ uninterruptibleMask_ $ trace log "sleep" $ cancellableSleep (1000 * ms) cancelled
+        timeout (500 * ms) action `shouldThrow` (== CancelException)
+        log "done"
+      -- the important property is that we always get "sleep"'s end/exception before "outer"'s end/exception
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "outer start"),
+                     (0, "sleep start"),
+                     (1000 * ms, "sleep end"),
+                     (1000 * ms, "outer exception"),
+                     (1000 * ms, "done")
+                   ]
+    it "bubbles an exception that occurs before cancelling" $ do
+      (cancel, cancelled) <- getCancel
+      events <- withLogger $ \log -> do
+        let action = trace log "outer" $ do
+              interruptOnAsyncException cancel $
+                uninterruptibleMask_ $
+                  trace log "sleep" $ do
+                    sleep (200 * ms)
+                    throwIO ActionException :: IO ()
+                    cancellableSleep (800 * ms) cancelled
+        timeout (500 * ms) action `shouldThrow` (== ActionException)
+        log "done"
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "outer start"),
+                     (0, "sleep start"),
+                     (200 * ms, "sleep exception"),
+                     (200 * ms, "outer exception"),
+                     (200 * ms, "done")
+                   ]
+    it "bubbles an exception that occurs after cancelling" $ do
+      (cancel, cancelled) <- getCancel
+      events <- withLogger $ \log -> do
+        let action = trace log "outer" $ do
+              interruptOnAsyncException cancel $
+                uninterruptibleMask_ $
+                  trace log "sleep" $ do
+                    cancellableSleep (1000 * ms) cancelled
+                    throwIO ActionException
+        timeout (500 * ms) action `shouldThrow` (== ActionException)
+        log "done"
+      roundLog (100 * ms) events
+        `shouldBe` [ (0, "outer start"),
+                     (0, "sleep start"),
+                     (500 * ms, "sleep exception"),
+                     (500 * ms, "outer exception"),
+                     (500 * ms, "done")
+                   ]
+
+-- millisecond in microseconds
+ms :: Int
+ms = 1000
+
+-- second in microseconds
+s :: Int
+s = 1000000
+
+sleep :: Int -> IO ()
+sleep = threadDelay
+
+cancellableSleep :: Int -> IO Bool -> IO ()
+cancellableSleep t cancelled = do
+  t0 <- getCurrentTime
+  let done = do
+        t1 <- getCurrentTime
+        return $ diffUTCTime t1 t0 * fromIntegral s >= fromIntegral t
+  spinUntil (liftM2 (||) done cancelled)
+  where
+    spinUntil cond = do
+      stop <- cond
+      when (not stop) $ do
+        threadDelay (1 * ms)
+        spinUntil cond
+
+getCancel :: IO (IO (), IO Bool)
+getCancel = do
+  c :: MVar () <- newEmptyMVar
+  let cancel = putMVar c ()
+      cancelled = maybe False (const True) <$> tryReadMVar c
+  return (cancel, cancelled)
+
+data CancelException = CancelException
+  deriving (Show, Eq)
+
+instance Exception CancelException
+
+data ActionException = ActionException
+  deriving (Show, Eq)
+
+instance Exception ActionException
+
+type Log = [(NominalDiffTime, String)]
+
+roundTo :: Int -> NominalDiffTime -> Int
+roundTo interval t = round (t * fromIntegral s / fromIntegral interval) * interval
+
+roundLog :: Int -> Log -> [(Int, String)]
+roundLog interval events = map (\(t, e) -> (roundTo interval t, e)) events
+
+withLogger :: ((String -> IO ()) -> IO ()) -> IO Log
+withLogger f = do
+  ref :: IORef Log <- newIORef []
+  t0 <- getCurrentTime
+  let log event = do
+        t <- getCurrentTime
+        atomicModifyIORef' ref (\events -> ((diffUTCTime t t0, event) : events, ()))
+  f log
+  reverse <$> readIORef ref
+
+trace :: (String -> IO ()) -> String -> IO () -> IO ()
+trace log label action = do
+  log $ label <> " start"
+  action `onException` (log $ label <> " exception")
+  log $ label <> " end"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,6 +13,7 @@ import Database.PG.Query
 import Interrupt (specInterrupt)
 import System.Environment qualified as Env
 import Test.Hspec
+import Timeout (specTimeout)
 
 {- Note [Running tests]
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -39,6 +40,7 @@ main = hspec $ do
     it "time out works correctly" do
       releaseAndAcquireWithTimeoutNegative `shouldReturn` Nothing
   specInterrupt
+  specTimeout
 
 mkPool :: IO PGPool
 mkPool = do
@@ -49,7 +51,7 @@ mkPool = do
     ciRetries = 0
     mkDetails = CDDatabaseURI
     logger = mempty
-    connParams = ConnParams 1 1 60 True Nothing (Just 3)
+    connParams = ConnParams 1 1 60 True Nothing (Just 3) False
 
 withFreshPool :: (FromPGTxErr e, FromPGConnErr e) => PGPool -> IO a -> IO (Either e a)
 withFreshPool pool action =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,6 +10,7 @@ import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad.Except (MonadTrans (lift), runExceptT)
 import Data.ByteString.Char8 qualified as BS
 import Database.PG.Query
+import Interrupt (specInterrupt)
 import System.Environment qualified as Env
 import Test.Hspec
 
@@ -37,6 +38,7 @@ main = hspec $ do
       releaseAndAcquireWithTimeout `shouldReturn` Nothing
     it "time out works correctly" do
       releaseAndAcquireWithTimeoutNegative `shouldReturn` Nothing
+  specInterrupt
 
 mkPool :: IO PGPool
 mkPool = do

--- a/test/Timeout.hs
+++ b/test/Timeout.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Timeout (specTimeout) where
+
+import Control.Concurrent.Async (async, wait)
+import Control.Monad.Except (runExceptT)
+import Control.Monad.Identity (Identity (..), runIdentity)
+import Data.ByteString.Char8 qualified as BS
+import Data.Int (Int32)
+import Data.Time (diffUTCTime, getCurrentTime)
+import Database.PG.Query
+import System.Environment qualified as Env
+import System.Timeout (timeout)
+import Test.Hspec
+
+specTimeout :: Spec
+specTimeout = before initDB $ do
+  describe "slow insert" $ do
+    it "inserts a row successfully if not interrupted" $ \pool -> do
+      countRows pool `shouldReturn` 0
+      t0 <- getCurrentTime
+      res <- sleepyInsert pool 1
+      t1 <- getCurrentTime
+      res `shouldBe` Right ()
+      diffUTCTime t1 t0 `shouldSatisfy` (\x -> x >= 1 && x < 2)
+      countRows pool `shouldReturn` 1
+    it "is interrupted late by timeout" $ \pool -> do
+      countRows pool `shouldReturn` 0
+      t0 <- getCurrentTime
+      res <- timeout 500000 $ sleepyInsert pool 1
+      t1 <- getCurrentTime
+      -- timed out
+      res `shouldBe` Nothing
+      -- but still took the full second
+      diffUTCTime t1 t0 `shouldSatisfy` (\x -> x >= 1 && x < 2)
+    -- insert was rolled back
+    -- countRows pool `shouldReturn` 0
+    -- [note] This is true, but not something we want to assert.
+    -- 'runTx' runs independent IO actions to BEGIN and COMMIT
+    -- around the query. The async exception is delivered as
+    -- soon as the blocking FFI call for the query itself returns,
+    -- so neither COMMIT nor ABORT from 'asTransaction' get sent.
+    it "is not rolled back with async" $ \pool -> do
+      countRows pool `shouldReturn` 0
+      t0 <- getCurrentTime
+      res <- timeout 500000 $ do
+        a <- async $ sleepyInsert pool 1
+        wait a
+      t1 <- getCurrentTime
+      -- timed out
+      res `shouldBe` Nothing
+      -- quickly
+      diffUTCTime t1 t0 `shouldSatisfy` (\x -> x >= 0.5 && x < 0.75)
+      -- but the insert went through
+      countRows pool `shouldReturn` 1
+    it "is interrupted promptly with cancelling" $ \pool -> do
+      cancelablePool <- mkPool True
+      countRows pool `shouldReturn` 0
+      t0 <- getCurrentTime
+      res <- timeout 500000 $ sleepyInsert cancelablePool 1
+      t1 <- getCurrentTime
+      res `shouldBe` Nothing
+      -- promptly
+      diffUTCTime t1 t0 `shouldSatisfy` (\x -> x >= 0.5 && x < 0.75)
+      -- insert was rolled back
+      -- [note] This relies on the exception being delivered mid-transaction;
+      -- it's possible to have 'res == Nothing' (stating the request was timed
+      -- out) and have the transaction committed anyway, if the exception is
+      -- delivered after sending 'COMMIT' but before returning.
+      countRows pool `shouldReturn` 0
+
+mkPool :: Bool -> IO PGPool
+mkPool cancelable = do
+  dbUri <- BS.pack <$> Env.getEnv "DATABASE_URL"
+  initPGPool (connInfo dbUri) connParams logger
+  where
+    connInfo uri =
+      ConnInfo
+        { ciRetries = 0,
+          ciDetails = CDDatabaseURI uri
+        }
+    connParams =
+      ConnParams
+        { cpStripes = 1,
+          cpConns = 1,
+          cpIdleTime = 60,
+          cpAllowPrepare = True,
+          cpMbLifetime = Nothing,
+          cpTimeout = Nothing,
+          cpCancel = cancelable
+        }
+    logger event = putStrLn $ show event
+
+mode :: TxMode
+mode = (Serializable, Just ReadWrite)
+
+initDB :: IO PGPool
+initDB = do
+  pool <- mkPool False
+  let tx = multiQE PGExecErrTx (fromText statements)
+  res <- runExceptT $ runTx pool mode tx
+  res `shouldBe` Right ()
+  return pool
+  where
+    statements =
+      "DROP TABLE IF EXISTS test_timeout;\n\
+      \CREATE TABLE test_timeout (x int);\n\
+      \CREATE OR REPLACE FUNCTION sleepy(int) RETURNS int\n\
+      \  LANGUAGE sql AS\n\
+      \$$\n\
+      \  select pg_sleep($1);\n\
+      \  select $1\n\
+      \$$;\n"
+
+countRows :: PGPool -> IO Int
+countRows pool = do
+  res <- runExceptT $ runIdentity . getRow <$> runTx pool mode tx
+  let Right count = res
+  return count
+  where
+    query = "SELECT count(*) FROM test_timeout"
+    tx = withQE PGExecErrTx (fromText query) () False
+
+sleepyInsert :: PGPool -> Int32 -> IO (Either PGExecErr ())
+sleepyInsert pool sleep =
+  runExceptT $ runTx pool mode tx
+  where
+    query = "INSERT INTO test_timeout VALUES (sleepy($1))"
+    tx = withQE PGExecErrTx (fromText query) (Identity sleep) False


### PR DESCRIPTION
This is a minimal change to allow us to interrupt long running queries from within graphql-engine. It's meant to help address https://github.com/hasura/graphql-engine-mono/issues/1232.

It addresses the following bug:

> When `runTx` receives an asynchronous exception while waiting for a response from the database server, it isn't interrupted promptly. Instead, `runTx` is blocked in an FFI call until the server responds regularly.

This change runs the FFI calls asynchronously, and interrupts them by sending a [cancel message](https://www.postgresql.org/docs/current/libpq-cancel.html) to the server. (Thus, this change only helps in case the server is responsive.)

There's a bit of discussion on alternatives in the corresponding graphql-engine [RFC](https://github.com/hasura/graphql-engine-mono/blob/c025a90fe9779436bc0188a2bbf0ad95b5ed1f32/rfcs/operation-timeout-api-limits.md). In short:
- there are alternatives to unblocking the FFI calls, most notably `libpq` has a non-blocking mode (but this would be a far more invasive change)
- relying on async exceptions as a means of interrupting (and `System.Timeout.timeout` specifically) is not an obvious choice -- it might be preferable to e.g. pass a deadline to `runTx` instead
- by choosing to handle asynchronous exceptions according to "contract"/convention (i.e., dropping what we're doing and returning as quickly as possible), we lose the ability for the library user to determine whether a transaction was actually interrupted 
We've deemed these trade-offs acceptable for a first low-impact implementation of timeouts.