### PR TITLE
Fix inaccurate retry policy comment, and clarify current behaviour

### DIFF
--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -391,7 +391,8 @@ mkPGRetryPolicy noRetries =
     CR.limitRetriesByDelay limitDelay $
     CR.exponentialBackoff baseDelay <> CR.limitRetries noRetries
   where
-    limitDelay = 60 * 1000 * 100 -- 1 minute
+    -- limitDelay effectively clamps noRetries to <= 6
+    limitDelay = 6 * 1000 * 1000 -- 6 seconds
     baseDelay = 100 * 1000 -- 0.1 second
 
 data PGConn


### PR DESCRIPTION
The max delay was claimed to be 1 minute, the code (possibly a typo)
sets it to 6 seconds. The safe choice seems to be to correctly
document the current state, and possibly follow up by raising the
delay.

Note that this delay limit limits max number of retries in graphql-engine to 6.