### PR TITLE
Assorted refactoring of Connection and Pool modules

### DIFF
--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -26,12 +26,9 @@ module Database.PG.Query.Connection
     , mkTemplate
     , PrepArg
     , prepare
-    , execPrepared
     , execMulti
-    , execParams
     , execCmd
     , execQuery
-    , toByteString
     , lenientDecodeUtf8
     , PGErrInternal(..)
     , PGStmtErrDetail(..)
@@ -175,7 +172,7 @@ initPQConn ci logger =
 
     whenSerVerOk conn = do
       -- Set some parameters and check the response
-      mRes <- PQ.exec conn $ toByteString $ mconcat
+      mRes <- PQ.exec conn $ BL.toStrict $ BB.toLazyByteString $ mconcat
               [ BB.string7 "SET client_encoding = 'UTF8';"
               , BB.string7 "SET client_min_messages TO WARNING;"
               ]
@@ -188,10 +185,6 @@ initPQConn ci logger =
                             PGConnErr "unexpected status after setting params"
         Nothing  -> return $ Left $
                     PGConnErr "unexpected result after setting params"
-
-{-# INLINE toByteString #-}
-toByteString :: BB.Builder -> DB.ByteString
-toByteString = BL.toStrict . BB.toLazyByteString
 
 defaultConnInfo :: ConnInfo
 defaultConnInfo = ConnInfo 0 details
@@ -348,41 +341,6 @@ assertResCmd conn mRes = do
     checkResOk (ResultOkData _) = throwPGIntErr $
       PGIUnexpected "cmd expected; tuples found"
 
--- These are convenient wrappers around LibPQ's similar functions
-{-# INLINE prepare' #-}
-prepare'
-  :: PQ.Connection  -- ^ connection
-  -> RemoteKey      -- ^ stmtName
-  -> Template       -- ^ query
-  -> [PQ.Oid]       -- ^ paramTypes
-  -> PGExec ()      -- ^ result
-prepare' conn rk (Template t) ol = do
-  mRes <- liftIO $ PQ.prepare conn rk t $ Just ol
-  assertResCmd conn mRes
-
-{-# INLINE execPrepared #-}
-execPrepared
-  :: PQ.Connection                -- ^ connection
-  -> [Maybe (DB.ByteString, PQ.Format)]           -- ^ parameters
-  -> RemoteKey                    -- ^ stmtName
-  -> PGExec ResultOk -- ^ result
-execPrepared conn args n = do
-  mRes <- lift $ PQ.execPrepared conn n args PQ.Binary
-  checkResult conn mRes
-
--- Prevents a class of SQL injection attacks
-execParams
-  :: PQ.Connection                 -- ^ connection
-  -> Template                      -- ^ statement
-  -> [(PQ.Oid, Maybe (DB.ByteString, PQ.Format))]  -- ^ parameters
-  -> PGExec ResultOk  -- ^ result
-execParams conn (Template t) params = do
-  let params' = map (\(ty, v) -> prependToTuple2 ty <$> v) params
-  mRes <- lift $ PQ.execParams conn t params' PQ.Binary
-  checkResult conn mRes
-  where
-    prependToTuple2 a (b, c) = (a, b, c)
-
 mkPGRetryPolicy
   :: MonadIO m
   => Int           -- ^ number of retries
@@ -454,8 +412,8 @@ prepare
   -> Template
   -> [PQ.Oid]
   -> PGExec RemoteKey
-prepare (PGConn conn _ _ _ counter table _ _) t tl = do
-  let lk      = localKey t tl
+prepare (PGConn conn _ _ _ counter table _ _) tpl@(Template tplBytes) tl = do
+  let lk      = localKey tpl tl
   rkm <- lift $ HI.lookup table lk
   case rkm of
     -- Already prepared
@@ -466,7 +424,8 @@ prepare (PGConn conn _ _ _ counter table _ _) t tl = do
       -- Create a new unique remote key
       let rk = fromString $ show w
       -- prepare the statement
-      prepare' conn rk t tl
+      mRes <- lift $ PQ.prepare conn rk tplBytes $ Just tl
+      assertResCmd conn mRes
       lift $ do
         -- Insert into table
         HI.insert table lk rk
@@ -504,12 +463,17 @@ execQuery pgConn pgQuery = do
   withExceptT PGIUnexpected $ convF resOk
   where
     PGConn conn allowPrepare _ _ _ _ _ _ = pgConn
-    PGQuery t params preparable convF = pgQuery
-    withoutPrepare = execParams conn t params
+    PGQuery tpl@(Template tplBytes) params preparable convF = pgQuery
+    withoutPrepare = do
+      let prependToTuple2 a (b, c) = (a, b, c)
+          params' = map (\(ty, v) -> prependToTuple2 ty <$> v) params
+      mRes <- lift $ PQ.execParams conn tplBytes params' PQ.Binary
+      checkResult conn mRes
     withPrepare = do
       let (tl, vl) = unzip params
-      rk <- prepare pgConn t tl
-      execPrepared conn vl rk
+      rk <- prepare pgConn tpl tl
+      mRes <- lift $ PQ.execPrepared conn rk vl PQ.Binary
+      checkResult conn mRes
 
 {-# INLINE execMulti #-}
 execMulti

--- a/src/Database/PG/Query/Pool.hs
+++ b/src/Database/PG/Query/Pool.hs
@@ -16,7 +16,6 @@ module Database.PG.Query.Pool
   , initPGPool
   , destroyPGPool
   , withConn
-  , runTxOnConn'
   , beginTx
   , abortTx
   , commitTx
@@ -239,7 +238,7 @@ runTx :: ( MonadIO m
       -> TxET e m a
       -> ExceptT e m a
 runTx pool txm tx = do
-  withConn pool txm $ \connRsrc -> runTxOnConn' connRsrc tx
+  withConn pool txm $ \connRsrc -> execTx connRsrc tx
 
 runTx' :: ( MonadIO m
           , MonadBaseControl IO m
@@ -252,11 +251,6 @@ runTx' :: ( MonadIO m
 runTx' pool tx = do
   catchConnErr $
     withExpiringPGconn pool $ \connRsrc -> execTx connRsrc tx
-
-runTxOnConn' :: PGConn
-             -> TxET e m a
-             -> ExceptT e m a
-runTxOnConn' = execTx
 
 sql :: QuasiQuoter
 sql = QuasiQuoter { quoteExp = \a -> [|fromString a|] }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -55,7 +55,7 @@ mkPool = do
 withFreshPool :: (FromPGTxErr e, FromPGConnErr e) => PGPool -> IO a -> IO (Either e a)
 withFreshPool pool action =
   runExceptT
-    . withConn pool (ReadCommitted, Just ReadOnly)
+    . withConn pool
     . const $ lift action
 
 err :: Show a => a -> IO (Maybe String)


### PR DESCRIPTION
Individual commits have the details.

This unexports some functions which shouldn't be used externally, and which aren't as best as I can grep in graphql-engine.

(Are we aware of other users of this library?)