### PR TITLE
Improve error message for listen connection failure (fixes #30)

### DIFF
--- a/src/Database/PG/Query/Connection.hs
+++ b/src/Database/PG/Query/Connection.hs
@@ -20,6 +20,7 @@ module Database.PG.Query.Connection
     , PGConn(..)
     , resetPGConn
     , PGConnErr(..)
+    , readConnErr
     , ResultOk(..)
     , getPQRes
     , Template


### PR DESCRIPTION
This reads the libpq error message when `consumeInput` fails on a LISTEN connection.

Verified manually:

GHCI: 

```
> let connInfo = ...
> pool <- initPGPool connInfo defaultConnParams (const $ return ())
> runExceptT $ listen pool channel handler :: IO (Either PGExecErr ())
PNEOnStart
PNEPQNotify (Notify {notifyRelname = "mychan", notifyBePid = 5637, notifyExtra = ""})
FATAL:  terminating connection due to administrator command
Left PGConnErr {getConnErr = "server closed the connection unexpectedly\n\tThis probably means the server terminated abnormally\n\tbefore or while processing the request.\n"}
```

psql:

```
# NOTIFY "mychan";
# select * from pg_stat_activity where query like '%LISTEN%';
...
# select pg_terminate_backend(12345);
```
