### PR TITLE
Decode JSONB fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,4 +62,4 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: |
-          make test-all PROJECT='ci/${{ matrix.ghc }}/ci.project'
+          make test-ci PROJECT='ci/${{ matrix.ghc }}/ci.project'

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,14 @@ all:
 # in this repo
 DOCKER_POSTGRES_DATABASE_URL=postgresql://hasura:hasura@127.0.0.1:64001/hasura
 
+.PHONY: ormolu
+ormolu:
+	find src test bench -name '*.hs' | xargs ormolu -ie
+
 .PHONY: format
 format:
 	cabal-fmt -i pg-client.cabal
-	find src test bench -name '*.hs' | xargs ormolu -ie
+	make ormolu
 
 PROJECT ?= cabal.project
 CABAL = cabal --project=$(PROJECT)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: all
 all:
 
+# when running locally, use the postgres instance from the `docker-compose.yml`
+# in this repo
+DOCKER_POSTGRES_DATABASE_URL=postgresql://hasura:hasura@127.0.0.1:64001/hasura
+
 .PHONY: format
 format:
 	cabal-fmt -i pg-client.cabal
@@ -46,12 +50,23 @@ build-all:
 	  --enable-benchmarks \
 	  all
 
+.PHONY: start-dbs
+start-dbs:
+	docker-compose up -d
+	sleep 10
+
+.PHONY: stop-dbs
+stop-dbs:
+	docker-compose down -v
+
 .PHONY: test-all
-test-all:
+test-all: start-dbs
+	export DATABASE_URL=$(DOCKER_POSTGRES_DATABASE_URL) && \
 	$(CABAL) test \
 	  --enable-tests \
 	  --enable-benchmarks \
 	  all
+	make stop-dbs
 
 .PHONY: ghcid
 ghcid:

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ start-dbs:
 stop-dbs:
 	docker-compose down -v
 
+.PHONY: test-ci
+test-ci:
+	$(CABAL) test \
+	  --enable-tests \
+	  --enable-benchmarks \
+	  all
+
 .PHONY: test-all
 test-all: start-dbs
 	export DATABASE_URL=$(DOCKER_POSTGRES_DATABASE_URL) && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       POSTGRES_DB: "hasura"
     volumes:
         - postgres-data:/var/lib/postgresql/data
-        - ./docker-compose/postgres/init.sh:/docker-entrypoint-initdb.d/init-hasura.sh:ro
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.6"
+
+services:
+  postgres:
+    image: cimg/postgres:14.4-postgis@sha256:492a389895568e2f89a03c0c45c19350888611001123514623551a014e83a625
+    ports:
+      - "64001:5432"
+    environment:
+      POSTGRES_USER: "hasura"
+      POSTGRES_PASSWORD: "hasura"
+      POSTGRES_DB: "hasura"
+    volumes:
+        - postgres-data:/var/lib/postgresql/data
+        - ./docker-compose/postgres/init.sh:/docker-entrypoint-initdb.d/init-hasura.sh:ro
+
+volumes:
+  postgres-data:

--- a/pg-client.cabal
+++ b/pg-client.cabal
@@ -87,6 +87,7 @@ test-suite pg-client-test
   other-modules:
     Interrupt
     Timeout
+    Jsonb
 
   build-depends:
     , async
@@ -97,6 +98,9 @@ test-suite pg-client-test
     , safe-exceptions
     , time
     , transformers
+    , aeson
+    , mtl
+    , postgresql-libpq
 
 benchmark pg-client-bench
   import:         common-all

--- a/src/Database/PG/Query/Class.hs
+++ b/src/Database/PG/Query/Class.hs
@@ -24,7 +24,6 @@ where
 
 -------------------------------------------------------------------------------
 
-import Data.Bifunctor (first )
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Identity (Identity (..))
@@ -32,6 +31,7 @@ import Control.Monad.Trans.Except (ExceptT (..))
 import Data.Aeson (FromJSON, ToJSON, Value, encode, parseJSON)
 import Data.Aeson.Types (parseEither)
 import Data.Attoparsec.ByteString.Char8 qualified as Atto
+import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as Lazy (ByteString)
 import Data.Foldable (for_)
@@ -85,15 +85,15 @@ instance (FromJSON a) => FromCol (AltJ a) where
     case decodeJsonb of
       Right result -> pure result
       _ -> decodeJson
-      where
-        parse :: Value -> Either Text (AltJ a)
-        parse = fmap AltJ . first fromString . parseEither parseJSON
+    where
+      parse :: Value -> Either Text (AltJ a)
+      parse = fmap AltJ . first fromString . parseEither parseJSON
 
-        decodeJson :: Either Text (AltJ a)
-        decodeJson = fromColHelper PD.json_ast input >>= parse
+      decodeJson :: Either Text (AltJ a)
+      decodeJson = fromColHelper PD.json_ast input >>= parse
 
-        decodeJsonb :: Either Text (AltJ a)
-        decodeJsonb = fromColHelper PD.jsonb_ast input >>= parse
+      decodeJsonb :: Either Text (AltJ a)
+      decodeJsonb = fromColHelper PD.jsonb_ast input >>= parse
 
 type FromCol :: Type -> Constraint
 class FromCol a where

--- a/test/Jsonb.hs
+++ b/test/Jsonb.hs
@@ -41,7 +41,7 @@ getPostgresConnect = do
 
 specJsonb :: Spec
 specJsonb = do
-  describe "Feelings" $ do
+  describe "Decoding JSON and JSONB" $ do
     it "Querying 'json' from PostgreSQL" $ do
       pg <- getPostgresConnect
       SingleRow (Identity (i :: BS.ByteString)) <-

--- a/test/Jsonb.hs
+++ b/test/Jsonb.hs
@@ -21,6 +21,8 @@ import GHC.Generics
 import Test.Hspec
 import Prelude
 
+type TestValue :: *
+
 newtype TestValue = TestValue {hey :: Int}
   deriving stock (Show, Generic)
 

--- a/test/Jsonb.hs
+++ b/test/Jsonb.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-orphans -Wno-name-shadowing #-}
+
+module Jsonb (specJsonb) where
+
+import Control.Monad.Except
+import Control.Monad.Identity
+import Control.Monad.Reader
+import qualified Data.Aeson as J
+import qualified Data.ByteString as BS
+import Database.PG.Query
+import Database.PG.Query.Connection
+import Database.PostgreSQL.LibPQ.Internal
+import GHC.Generics
+import Test.Hspec
+import Prelude
+
+newtype TestValue = TestValue {hey :: Int}
+  deriving stock (Show, Generic)
+
+instance J.FromJSON TestValue
+
+stringface :: BS.ByteString
+stringface = "postgresql://hasura:hasura@127.0.0.1:65002/hasura"
+
+pgDb, cockroachDb :: ConnInfo
+pgDb =
+  defaultConnInfo
+    { ciDetails = CDDatabaseURI stringface
+    }
+cockroachDb =
+  defaultConnInfo
+    { ciDetails = CDDatabaseURI stringface
+    }
+
+specJsonb :: Spec
+specJsonb = do
+  describe "Feelings" $ do
+    it "Querying 'json' from PostgreSQL" $ do
+      SingleRow (Identity (i :: BS.ByteString)) <- runTxT pgDb (rawQE show "select '{\"hey\":42}'::json" [] False)
+      print i
+
+    it "Querying 'jsonb' from PostgreSQL (note the difference in formatting and \\SOH prefix)" $ do
+      SingleRow (Identity (i :: BS.ByteString)) <- runTxT pgDb (rawQE show "select '{\"hey\":42}'::jsonb" [] False)
+      print i
+
+    it "Querying 'json' from CockroachDB" $ do
+      SingleRow (Identity (i :: BS.ByteString)) <- runTxT cockroachDb (rawQE show "select '{\"hey\":42}'::json" [] False)
+      print i
+
+    it "Querying 'jsonb' from CockroachDB (note the difference in formatting and \\SOH prefix)" $ do
+      SingleRow (Identity (i :: BS.ByteString)) <- runTxT cockroachDb (rawQE show "select '{\"hey\":42}'::jsonb" [] False)
+      print i
+
+    -- This fails for both
+    it "Querying 'jsonb' from PostgreSQL" $ do
+      -- Note that 'AltJ' is simply a newtype wrapper that directs 'FromCol' to use 'FromJSON' to produce a Haskell Value of the specified type.
+      SingleRow (Identity (AltJ (i :: TestValue))) <- runTxT pgDb (rawQE show "select '{\"hey\":42}'::jsonb" [] False)
+      print i
+
+    it "Querying 'jsonb' from CockroachDB" $ do
+      SingleRow (Identity (AltJ (i :: TestValue))) <- runTxT cockroachDb (rawQE show "select '{\"hey\":42}'::json" [] False)
+      print i
+
+instance FromPGConnErr String where
+  fromPGConnErr = show
+
+runTxT :: forall a. ConnInfo -> TxET String IO a -> IO a
+runTxT conn q = do
+  pool <- initPGPool conn defaultConnParams (const (return ()))
+  x :: Either String a <- runExceptT $ runTx' pool q
+  destroyPGPool pool
+  case x of
+    Left e -> error e
+    Right r -> return r

--- a/test/Jsonb.hs
+++ b/test/Jsonb.hs
@@ -20,8 +20,9 @@ import Database.PostgreSQL.LibPQ.Internal
 import GHC.Generics
 import Test.Hspec
 import Prelude
+import Data.Kind (Type)
 
-type TestValue :: *
+type TestValue :: Type 
 
 newtype TestValue = TestValue {hey :: Int}
   deriving stock (Show, Generic)

--- a/test/Jsonb.hs
+++ b/test/Jsonb.hs
@@ -57,7 +57,7 @@ specJsonb = do
         (Right (SingleRow (Identity (_ :: BS.ByteString)))) -> True
         Left e -> error e
 
-    it "Querying 'jsonb' from PostgreSQL (note the difference in formatting and \\SOH prefix) succeeds" $ do
+    it "Querying 'jsonb' from PostgreSQL succeeds" $ do
       pg <- getPostgresConnect
       result <-
         runTxT
@@ -68,7 +68,18 @@ specJsonb = do
         Right (SingleRow (Identity (_ :: BS.ByteString))) -> True
         Left e -> error e
 
-    it "Querying 'jsonb' from PostgreSQL succeeds" $ do
+    it "Querying 'json' from PostgreSQL into AltJ type succeeds" $ do
+      pg <- getPostgresConnect
+      result <-
+        runTxT
+          pg
+          (rawQE show "select '{\"hey\":42}'::json" [] False)
+
+      result `shouldSatisfy` \case
+        Right (SingleRow (Identity (AltJ (_ :: TestValue)))) -> True
+        Left e -> error e
+
+    it "Querying 'jsonb' from PostgreSQL into AltJ type succeeds" $ do
       pg <- getPostgresConnect
       result <-
         runTxT

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -14,6 +14,7 @@ import Control.Monad.Trans.Except (runExceptT)
 import Data.ByteString.Char8 qualified as BS
 import Database.PG.Query
 import Interrupt (specInterrupt)
+import Jsonb (specJsonb)
 import System.Environment qualified as Env
 import Test.Hspec (describe, hspec, it, shouldReturn)
 import Timeout (specTimeout)
@@ -47,6 +48,7 @@ main = hspec $ do
       releaseAndAcquireWithTimeoutNegative `shouldReturn` Nothing
   specInterrupt
   specTimeout
+  specJsonb
 
 mkPool :: IO PGPool
 mkPool = do


### PR DESCRIPTION
This changes the `FromJSON` instance for the `AltJ` to try the `JSONB` decoder and then the `JSON` decoder.

These tests are taken from the CockroachDB proof of concept, and pass once these changes are made.

This should resolve: https://github.com/hasura/graphql-engine/issues/8791