### PR TITLE
Readme update for migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A low level Postgres client library for Haskell. Used at Hasura in various production projects.
 
+This library is no longer developed here, but remains in case it is used as a
+project dependency. All further updates can be found in the
+[graphql-engine](https://github.com/hasura/graphql-engine-mono/tree/main/server/lib/pg-client-hs) repository.
+
 ## Style
 
 This repository follows the graphql-engine

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A low level Postgres client library for Haskell. Used at Hasura in various produ
 
 This library is no longer developed here, but remains in case it is used as a
 project dependency. All further updates can be found in the
-[graphql-engine](https://github.com/hasura/graphql-engine-mono/tree/main/server/lib/pg-client-hs) repository.
+[graphql-engine](https://github.com/hasura/graphql-engine/tree/main/server/lib/pg-client-hs) repository.
 
 ## Style
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 A low level Postgres client library for Haskell. Used at Hasura in various production projects.
 
-This library is no longer developed here, but remains in case it is used as a
-project dependency. All further updates can be found in the
+The code for this library has now moved to another git repository, and can be
+found here: 
 [graphql-engine](https://github.com/hasura/graphql-engine/tree/main/server/lib/pg-client-hs) repository.
 
 ## Style


### PR DESCRIPTION
This repository has been moved into `graphql-engine`, updating readme to reflect this.